### PR TITLE
add source discovery to source.py

### DIFF
--- a/src/airflow_framework/source_class/source.py
+++ b/src/airflow_framework/source_class/source.py
@@ -8,10 +8,15 @@ class DagBuilder(ABC):
     """
     A base DAG buider
     """
+    sources = []
 
     def __init__(self, default_task_args: dict):
         self.default_task_args = default_task_args
         super().__init__()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.sources.append(cls())
 
     @abstractmethod
     def build_dags(self, config: DataSourceTablesConfig):


### PR DESCRIPTION
Looked through a few external plugin managers first to see if they would make sense for our purposes, but they seemed quite bulky and unnecessarily complicated in a lot of ways. 

Turns out there's an incredibly simple way to get this working: 
(1) define a field within DagBuilder to store all initialized subclasses (I called it sources)
(2) define an __init_subclass__ method that is called every time a subclass is initialized (and that instance is pushed to the sources field)

This lets us easily iterate over DagBuilder.sources in parse_dags.py to find the matching DagBuilder by whatever field we want (e.g. just the source name). So something like this:

```
for config in configs:
    for source in DagBuilder.sources
        if config.name == source.name:
            return source
    ....
```

would do the trick, as long as the base class and all subclasses that we want to be discoverable are imported correctly.