### PR TITLE
Schema parsing method and DagBuilder class refactoring (AF-43)

### DIFF
--- a/src/gcp_airflow_foundations/base_class/schema_options_config.py
+++ b/src/gcp_airflow_foundations/base_class/schema_options_config.py
@@ -1,0 +1,28 @@
+from dacite import Config
+from pydantic import validator, root_validator
+from pydantic.dataclasses import dataclass
+
+from typing import List, Optional
+import regex as re
+
+from gcp_airflow_foundations.enums.schema_source_type import SchemaSourceType
+
+supported_fields = ['table_name','date']
+
+@dataclass
+class SchemaOptionsConfig:
+    schema_source_type: SchemaSourceType
+    schema_object_template: Optional[str] # Supported tamplate fields: {table_name}, {date}
+    
+    @root_validator(pre=True)
+    def valid_config(cls, values):
+        if values['schema_source_type'] == SchemaSourceType.GCS:
+            assert values['schema_object_template'] is not None, 'To read schema from GCS a file template must be provided'
+        return values
+
+    @validator("schema_object_template")
+    def valid_schema_object_template(cls, v):
+        if v is not None:
+            fields = re.findall(r'\{(.*?)\}', v)
+            assert all([i in supported_fields for i in fields]), f'The GCS schema file template contains invalid fields: {[i for i in fields if i not in supported_fields]}'
+        return v

--- a/src/gcp_airflow_foundations/base_class/source_config.py
+++ b/src/gcp_airflow_foundations/base_class/source_config.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 
 from gcp_airflow_foundations.enums.source_type import SourceType
 from gcp_airflow_foundations.base_class.landing_zone_config import LandingZoneConfig
+from gcp_airflow_foundations.base_class.schema_options_config import SchemaOptionsConfig
 
 partition_limit = 4000
 ms_day = 86400000
@@ -49,6 +50,7 @@ class SourceConfig:
     notification_emails: List[str]
     owner: str
     partition_expiration: Optional[int]
+    schema_options: SchemaOptionsConfig
     start_date: str
     start_date_tz: str = "EST"
     version: int = 1
@@ -79,6 +81,11 @@ class SourceConfig:
     def valid_start_date(cls, v):
         assert datetime.datetime.strptime(v, "%Y-%m-%d"), \
             "The date format for Start Date should be YYYY-MM-DD"
+        return v
+
+    @validator("schema_options")
+    def valid_schema_options(cls, v):
+        assert v is not None, 'Schema options configuration must be provided'
         return v
 
     @root_validator(pre=True)

--- a/src/gcp_airflow_foundations/base_class/source_table_config.py
+++ b/src/gcp_airflow_foundations/base_class/source_table_config.py
@@ -24,7 +24,6 @@ class SourceTableConfig:
         ingestion_type: FULL or INCREMENTAL
         landing_zone_table_name_override: Optional staging zone table name.
         dest_table_override: Optional target table name. If None, use table_name instead
-        source_table_schema_object: GCS schema object URI
         surrogate_keys : Keys used to identify unique records when merging into ODS
         column_mapping : Mapping used to rename columns
         ods_config : See OdsTableConfig
@@ -38,7 +37,6 @@ class SourceTableConfig:
     ingestion_type: IngestionType # FULL or INCREMENTAL
     landing_zone_table_name_override: Optional[str]
     dest_table_override: Optional[str]
-    source_table_schema_object: Optional[str]
     surrogate_keys: List[str]
     column_mapping: Optional[dict]
     ods_config: Optional[OdsTableConfig]

--- a/src/gcp_airflow_foundations/common/gcp/hds/schema_utils.py
+++ b/src/gcp_airflow_foundations/common/gcp/hds/schema_utils.py
@@ -1,19 +1,9 @@
-from gcp_airflow_foundations.common.gcp.source_schema.gcs import read_schema_from_gcs
 from gcp_airflow_foundations.enums.hds_table_type import HdsTableType
-
 
 def parse_hds_schema(
     hds_metadata,
     hds_table_type,
-    gcs_schema_object=None,
-    schema_fields=None,
-    column_mapping=None) -> list:
-
-    source_schema_fields, source_table_columns = read_schema_from_gcs(
-        gcs_schema_object=gcs_schema_object,
-        schema_fields=schema_fields,
-        column_mapping=column_mapping
-    )
+    schema_fields) -> list:
 
     HDS_EXTRA_FIELDS_SCD2 = [
         {
@@ -45,10 +35,14 @@ def parse_hds_schema(
         }
     ]
 
+    hds_schema_fields = []
+
+    hds_schema_fields.extend(schema_fields)
+
     if hds_table_type == HdsTableType.SCD2:
-        source_schema_fields.extend(HDS_EXTRA_FIELDS_SCD2)
+        hds_schema_fields.extend(HDS_EXTRA_FIELDS_SCD2)
 
     elif hds_table_type == HdsTableType.SNAPSHOT:
-        source_schema_fields.extend(HDS_EXTRA_FIELDS_SNAPSHOT)
+        hds_schema_fields.extend(HDS_EXTRA_FIELDS_SNAPSHOT)
 
-    return source_schema_fields, source_table_columns    
+    return hds_schema_fields

--- a/src/gcp_airflow_foundations/common/gcp/load_builder.py
+++ b/src/gcp_airflow_foundations/common/gcp/load_builder.py
@@ -9,25 +9,28 @@ import logging
 
 
 def load_builder(
-    project_id,
-    table_id,
-    dataset_id,
-    landing_zone_dataset,
-    landing_zone_table_name_override,
-    surrogate_keys,
-    column_mapping,
+    data_source,
+    table_config,
     schema_config,
-    ingestion_type,
-    partition_expiration,
-    hds_table_config,
-    ods_table_config,
     preceding_task,
     dag):
 
     """
     Method for building all needed Task Groups based on the HdsTableConfig and OdsTableConfig options declared in the config files
     """
-    
+
+    project_id = data_source.gcp_project
+    table_id = table_config.table_name
+    dataset_id = data_source.dataset_data_name
+    landing_zone_dataset = data_source.landing_zone_options.landing_zone_dataset
+    landing_zone_table_name_override = table_config.landing_zone_table_name_override
+    surrogate_keys = table_config.surrogate_keys
+    column_mapping = table_config.column_mapping
+    ingestion_type = table_config.ingestion_type
+    partition_expiration = data_source.partition_expiration
+    ods_table_config = table_config.ods_config
+    hds_table_config = table_config.hds_config
+
     if ingestion_type == IngestionType.INCREMENTAL:
         ods_table_config.table_id = f"{table_id}_ODS_Incremental"
 
@@ -38,8 +41,8 @@ def load_builder(
         task_id="schema_parsing",
         schema_config=schema_config,
         column_mapping=column_mapping,
-        ods_table_config=ods_table_config,
-        hds_table_config=hds_table_config,
+        data_source=data_source,
+        table_config=table_config,
         dag=dag
     )
 

--- a/src/gcp_airflow_foundations/common/gcp/load_builder.py
+++ b/src/gcp_airflow_foundations/common/gcp/load_builder.py
@@ -1,11 +1,12 @@
 from gcp_airflow_foundations.operators.gcp.hds.load_hds_taskgroup import hds_builder
 from gcp_airflow_foundations.operators.gcp.ods.load_ods_taskgroup import ods_builder
-from gcp_airflow_foundations.operators.gcp.schema_migration.schema_migration_operator import MigrateSchema
 
-from gcp_airflow_foundations.common.gcp.ods.schema_utils import parse_ods_schema
-from gcp_airflow_foundations.common.gcp.hds.schema_utils import parse_hds_schema
+from gcp_airflow_foundations.operators.gcp.schema_parsing.schema_parsing_operator import ParseSchema
+from gcp_airflow_foundations.enums.ingestion_type import IngestionType
+from gcp_airflow_foundations.enums.hds_table_type import HdsTableType
 
 import logging
+
 
 def load_builder(
     project_id,
@@ -15,8 +16,7 @@ def load_builder(
     landing_zone_table_name_override,
     surrogate_keys,
     column_mapping,
-    gcs_schema_object,
-    schema_fields,
+    schema_config,
     ingestion_type,
     partition_expiration,
     hds_table_config,
@@ -27,69 +27,58 @@ def load_builder(
     """
     Method for building all needed Task Groups based on the HdsTableConfig and OdsTableConfig options declared in the config files
     """
+    
+    if ingestion_type == IngestionType.INCREMENTAL:
+        ods_table_config.table_id = f"{table_id}_ODS_Incremental"
 
-    builders = []
+    elif ingestion_type == IngestionType.FULL:
+        ods_table_config.table_id = f"{table_id}_ODS_Full"
 
-    ods_schema_fields, source_table_columns = parse_ods_schema(
-        gcs_schema_object=gcs_schema_object,
-        schema_fields=schema_fields,
+    parse_schema = ParseSchema(
+        task_id="schema_parsing",
+        schema_config=schema_config,
         column_mapping=column_mapping,
-        ods_metadata=ods_table_config.ods_metadata
+        ods_table_config=ods_table_config,
+        hds_table_config=hds_table_config,
+        dag=dag
     )
 
-    logging.info(f"ODS table schema: {ods_schema_fields}")
-
-    ods_task_group, ods_table_id = ods_builder(
+    ods_task_group= ods_builder(
         project_id=project_id,
-        table_id=table_id,
+        table_id=ods_table_config.table_id,
         dataset_id=dataset_id,
         landing_zone_dataset=landing_zone_dataset,
         landing_zone_table_name_override=landing_zone_table_name_override,
         surrogate_keys=surrogate_keys,
         column_mapping=column_mapping,
-        columns=source_table_columns,
-        schema_fields=ods_schema_fields,
         ingestion_type=ingestion_type,
         ods_table_config=ods_table_config,
         dag=dag
     )
     
-    builders.append(ods_task_group)
-
     hds_task_group = None
     if hds_table_config:
-        hds_schema_fields, source_table_columns = parse_hds_schema(
-            gcs_schema_object=gcs_schema_object,
-            schema_fields=schema_fields,
-            column_mapping=column_mapping,
-            hds_metadata=hds_table_config.hds_metadata,
-            hds_table_type=hds_table_config.hds_table_type
-        )
+        if hds_table_config.hds_table_type == HdsTableType.SNAPSHOT:
+            hds_table_config.table_id = f"{table_id}_HDS_Snapshot"
+        
+        elif hds_table_config.hds_table_type == HdsTableType.SCD2:
+            hds_table_config.table_id = f"{table_id}_HDS_SCD2"
 
-        logging.info(f"HDS table schema: {hds_schema_fields}")
-
-        # the source dataset/table of the HDS is the ODS
         hds_task_group = hds_builder(
             project_id=project_id,
-            table_id=table_id,
+            table_id=hds_table_config.table_id,
             dataset_id=dataset_id,
             landing_zone_dataset=dataset_id,
-            landing_zone_table_name_override=ods_table_id,
-            surrogate_keys=[column_mapping[i] for i in source_table_columns if i in surrogate_keys],
-            column_mapping={column_mapping[i]:column_mapping[i] for i in source_table_columns},
-            columns=[column_mapping[i] for i in source_table_columns],
-            schema_fields=hds_schema_fields,
+            landing_zone_table_name_override=ods_table_config.table_id,
+            surrogate_keys=[column_mapping[i] for i in surrogate_keys],
+            column_mapping=column_mapping,
             ingestion_type=ingestion_type,
             partition_expiration=partition_expiration,
             hds_table_config=hds_table_config,
             dag=dag
         )
-        
-        builders.append(hds_task_group)
 
     if hds_task_group:
-        preceding_task >> ods_task_group >> hds_task_group
+        preceding_task >> parse_schema >> ods_task_group >> hds_task_group
     else:
-        preceding_task >> ods_task_group
-
-    return builders
+        preceding_task >> parse_schema >> ods_task_group

--- a/src/gcp_airflow_foundations/common/gcp/ods/schema_utils.py
+++ b/src/gcp_airflow_foundations/common/gcp/ods/schema_utils.py
@@ -1,17 +1,6 @@
-from gcp_airflow_foundations.common.gcp.source_schema.gcs import read_schema_from_gcs
-
-
 def parse_ods_schema(
     ods_metadata,
-    gcs_schema_object=None,
-    schema_fields=None,
-    column_mapping=None) -> list:
-
-    source_schema_fields, source_table_columns = read_schema_from_gcs(
-        gcs_schema_object=gcs_schema_object,
-        schema_fields=schema_fields,
-        column_mapping=column_mapping
-    )
+    schema_fields) -> list:
 
     ODS_EXTRA_FIELDS = [
         {
@@ -32,6 +21,9 @@ def parse_ods_schema(
         }
     ]
 
-    source_schema_fields.extend(ODS_EXTRA_FIELDS)
+    ods_schema_fields = []
 
-    return source_schema_fields, source_table_columns    
+    ods_schema_fields.extend(schema_fields)
+    ods_schema_fields.extend(ODS_EXTRA_FIELDS)
+
+    return ods_schema_fields    

--- a/src/gcp_airflow_foundations/common/gcp/source_schema/bq.py
+++ b/src/gcp_airflow_foundations/common/gcp/source_schema/bq.py
@@ -4,8 +4,8 @@ import logging
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
 
 def read_schema_from_bq(
-    staging_dataset_id,
-    staging_table_id,
+    dataset_id,
+    table_id,
     google_cloud_storage_conn_id='google_cloud_default',
     bigquery_conn_id='google_cloud_default',
     **kwargs) -> list:
@@ -16,8 +16,8 @@ def read_schema_from_bq(
     bq_hook = BigQueryHook(bigquery_conn_id=bigquery_conn_id, delegate_to=None)
 
     schema = bq_hook.get_schema(
-        dataset_id=staging_dataset_id,
-        table_id=staging_table_id
+        dataset_id=dataset_id,
+        table_id=table_id
     )
 
     return schema['fields']

--- a/src/gcp_airflow_foundations/common/gcp/source_schema/bq.py
+++ b/src/gcp_airflow_foundations/common/gcp/source_schema/bq.py
@@ -1,0 +1,23 @@
+import json
+import logging
+
+from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+
+def read_schema_from_bq(
+    staging_dataset_id,
+    staging_table_id,
+    google_cloud_storage_conn_id='google_cloud_default',
+    bigquery_conn_id='google_cloud_default',
+    **kwargs) -> list:
+    """
+        Helper method to load table schema from the staging table
+    """
+
+    bq_hook = BigQueryHook(bigquery_conn_id=bigquery_conn_id, delegate_to=None)
+
+    schema = bq_hook.get_schema(
+        dataset_id=staging_dataset_id,
+        table_id=staging_table_id
+    )
+
+    return schema['fields']

--- a/src/gcp_airflow_foundations/common/gcp/source_schema/gcs.py
+++ b/src/gcp_airflow_foundations/common/gcp/source_schema/gcs.py
@@ -10,37 +10,26 @@ from urllib.parse import urlparse
 
 
 def read_schema_from_gcs(
-    gcs_schema_object=None,
-    schema_fields=None, 
-    column_mapping=None,
+    gcs_schema_object,
     google_cloud_storage_conn_id='google_cloud_default',
-    bigquery_conn_id='google_cloud_default') -> list:
+    bigquery_conn_id='google_cloud_default',
+    **kwargs) -> list:
     """
-        Helper method to load table schema from a GCS URI, unless a list of schema fields is provided to be used instead.
+        Helper method to load table schema from a GCS URI
     """
-
+    
     bq_hook = BigQueryHook(bigquery_conn_id=bigquery_conn_id, delegate_to=None)
 
-    if not schema_fields and gcs_schema_object:
+    parsed_url = urlparse(gcs_schema_object)
+    gcs_bucket = parsed_url.netloc
+    gcs_object = parsed_url.path.lstrip('/')
 
-        parsed_url = urlparse(gcs_schema_object)
-        gcs_bucket = parsed_url.netloc
-        gcs_object = parsed_url.path.lstrip('/')
+    gcs_hook = GoogleCloudStorageHook(
+        google_cloud_storage_conn_id=google_cloud_storage_conn_id,
+        delegate_to=None)
 
-        gcs_hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=google_cloud_storage_conn_id,
-            delegate_to=None)
-        schema_fields = json.loads(gcs_hook.download(
-            gcs_bucket,
-            gcs_object).decode("utf-8"))
-    else:
-        schema_fields = schema_fields
+    schema_fields = json.loads(gcs_hook.download(
+        gcs_bucket,
+        gcs_object).decode("utf-8"))
 
-    source_table_columns = [field["name"] for field in schema_fields]
-
-    if column_mapping:
-        for field in schema_fields:
-            if field["name"] in column_mapping.keys():
-                field["name"] = column_mapping[field["name"]]
-
-    return schema_fields, source_table_columns
+    return schema_fields

--- a/src/gcp_airflow_foundations/enums/schema_source_type.py
+++ b/src/gcp_airflow_foundations/enums/schema_source_type.py
@@ -4,5 +4,6 @@ from enum import Enum, unique
 @unique
 class SchemaSourceType(Enum):
     GCS = "GCS"
-    LANDINGZONE = "LANDINGZONE"
+    BQ = "BQ"
     CUSTOM = "CUSTOM"
+    AUTO = "AUTO"

--- a/src/gcp_airflow_foundations/enums/schema_source_type.py
+++ b/src/gcp_airflow_foundations/enums/schema_source_type.py
@@ -1,0 +1,8 @@
+from enum import Enum, unique
+
+
+@unique
+class SchemaSourceType(Enum):
+    GCS = "GCS"
+    LANDINGZONE = "LANDINGZONE"
+    CUSTOM = "CUSTOM"

--- a/src/gcp_airflow_foundations/operators/gcp/create_table.py
+++ b/src/gcp_airflow_foundations/operators/gcp/create_table.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from airflow.models import BaseOperator, BaseOperatorLink
+from airflow.contrib.operators.bigquery_operator import (
+    BigQueryOperator,
+    BigQueryCreateEmptyTableOperator,
+)
+
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+
+from airflow.exceptions import AirflowException
+
+import logging
+
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryCreateEmptyTableOperator
+)
+
+
+class CustomBigQueryCreateEmptyTableOperator(BigQueryCreateEmptyTableOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        dataset_id: str,
+        table_id: str,
+        time_partitioning: Optional[dict] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ) -> None:
+        super(CustomBigQueryCreateEmptyTableOperator, self).__init__(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            table_resource=None,
+            exists_ok=True,
+            **kwargs,
+        )
+
+        self.table = table_id
+        self.time_partitioning = time_partitioning
+
+    def pre_execute(self, context) -> None:
+        schema_fields = self.xcom_pull(context=context, task_ids="schema_parsing")[self.table_id]
+
+        self.table_resource={
+                "schema":{'fields': schema_fields},
+                "timePartitioning":self.time_partitioning,
+                "encryptionConfiguration":None,
+                "labels":None
+        }

--- a/src/gcp_airflow_foundations/operators/gcp/create_table.py
+++ b/src/gcp_airflow_foundations/operators/gcp/create_table.py
@@ -27,6 +27,7 @@ class CustomBigQueryCreateEmptyTableOperator(BigQueryCreateEmptyTableOperator):
         dataset_id: str,
         table_id: str,
         time_partitioning: Optional[dict] = None,
+        schema_task_id: Optional[str] = "schema_parsing"
         gcp_conn_id: str = "google_cloud_default",
         **kwargs,
     ) -> None:
@@ -41,9 +42,10 @@ class CustomBigQueryCreateEmptyTableOperator(BigQueryCreateEmptyTableOperator):
 
         self.table = table_id
         self.time_partitioning = time_partitioning
+        self.schema_task_id = schema_task_id
 
     def pre_execute(self, context) -> None:
-        schema_fields = self.xcom_pull(context=context, task_ids="schema_parsing")[self.table_id]
+        schema_fields = self.xcom_pull(context=context, task_ids=self.schema_task_id)[self.table_id]
 
         self.table_resource={
                 "schema":{'fields': schema_fields},

--- a/src/gcp_airflow_foundations/operators/gcp/gcs_to_bigquery.py
+++ b/src/gcp_airflow_foundations/operators/gcp/gcs_to_bigquery.py
@@ -1,0 +1,54 @@
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+
+from airflow.utils.decorators import apply_defaults
+
+from gcp_airflow_foundations.source_class.schema_source_config import SchemaSourceConfig
+from gcp_airflow_foundations.base_class.source_table_config import SourceTableConfig
+from gcp_airflow_foundations.base_class.source_config import SourceConfig
+
+import logging
+
+
+class CustomGCSToBigQueryOperator(GCSToBigQueryOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        schema_config: SchemaSourceConfig,
+        data_source: SourceConfig, 
+        table_config: SourceTableConfig,
+        bucket: str,
+        source_objects: str,
+        destination_project_dataset_table: str,
+        write_disposition: str,
+        create_disposition: str,
+        skip_leading_rows: int,
+        **kwargs,
+    ) -> None:
+        super(CustomGCSToBigQueryOperator, self).__init__(
+            bucket=bucket,
+            source_objects=source_objects,
+            destination_project_dataset_table=destination_project_dataset_table,
+            write_disposition=write_disposition,
+            create_disposition=create_disposition,
+            skip_leading_rows=skip_leading_rows,
+            **kwargs,
+        )
+
+        self.schema_config = schema_config
+        self.data_source = data_source
+        self.table_config = table_config
+
+    def pre_execute(self, context) -> None:
+        schema_source_config_class = self.schema_config
+
+        logging.info(f"Parsing schema for staging table using `{schema_source_config_class.__name__}`")
+
+        schema_method = schema_source_config_class().schema_method()
+        schema_method_arguments = schema_source_config_class().schema_method_arguments(self.data_source, self.table_config)
+
+        if schema_method and schema_method_arguments:
+            self.schema_fields = schema_method(**schema_method_arguments)
+        else:
+            self.schema_fields = None
+            self.autodetect = True

--- a/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
@@ -95,6 +95,7 @@ class MergeBigQueryHDS(BigQueryOperator):
 
     def pre_execute(self, context) -> None:
         columns = [self.column_mapping[i] for i in self.xcom_pull(context=context, task_ids="schema_parsing")['source_table_columns']]
+        column_mapping = {self.column_mapping[i]:self.column_mapping[i] for i in self.column_mapping}
 
         self.log.info(
             f"Execute BigQueryMergeTableOperator {self.stg_table_name}, {self.data_table_name}"
@@ -109,7 +110,7 @@ class MergeBigQueryHDS(BigQueryOperator):
             target=self.data_table_name,
             columns=columns,
             surrogate_keys=self.surrogate_keys,
-            column_mapping={self.column_mapping[i]:self.column_mapping[i] for i in self.column_mapping},
+            column_mapping=column_mapping,
             hds_metadata=self.hds_table_config.hds_metadata
         )
 

--- a/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
@@ -67,7 +67,6 @@ class MergeBigQueryHDS(BigQueryOperator):
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = "google_cloud_default",
         column_mapping: dict,
-        columns: list,
         ingestion_type: IngestionType,
         hds_table_config: HdsTableConfig,
         **kwargs,
@@ -91,11 +90,12 @@ class MergeBigQueryHDS(BigQueryOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.column_mapping = column_mapping
-        self.columns = columns
         self.ingestion_type = ingestion_type
         self.hds_table_config = hds_table_config
 
     def pre_execute(self, context) -> None:
+        columns = [self.column_mapping[i] for i in self.xcom_pull(context=context, task_ids="schema_parsing")['source_table_columns']]
+
         self.log.info(
             f"Execute BigQueryMergeTableOperator {self.stg_table_name}, {self.data_table_name}"
         )
@@ -107,9 +107,9 @@ class MergeBigQueryHDS(BigQueryOperator):
             target_dataset=self.data_dataset_name,
             source=self.stg_table_name,
             target=self.data_table_name,
-            columns=self.columns,
+            columns=columns,
             surrogate_keys=self.surrogate_keys,
-            column_mapping=self.column_mapping,
+            column_mapping={self.column_mapping[i]:self.column_mapping[i] for i in self.column_mapping},
             hds_metadata=self.hds_table_config.hds_metadata
         )
 

--- a/src/gcp_airflow_foundations/operators/gcp/hds/load_hds_taskgroup.py
+++ b/src/gcp_airflow_foundations/operators/gcp/hds/load_hds_taskgroup.py
@@ -13,6 +13,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from gcp_airflow_foundations.operators.gcp.hds.hds_merge_table_operator import MergeBigQueryHDS
 from gcp_airflow_foundations.operators.gcp.schema_migration.schema_migration_operator import MigrateSchema
 
+from gcp_airflow_foundations.operators.gcp.create_table import CustomBigQueryCreateEmptyTableOperator
 
 def hds_builder(
     project_id,
@@ -21,8 +22,6 @@ def hds_builder(
     landing_zone_dataset,
     landing_zone_table_name_override,
     column_mapping,
-    columns,
-    schema_fields,
     surrogate_keys,
     ingestion_type,
     hds_table_config,
@@ -39,35 +38,23 @@ def hds_builder(
     taskgroup = TaskGroup(group_id="create_hds_merge_taskgroup")
 
     if hds_table_config.hds_table_type == HdsTableType.SNAPSHOT:
-        table_id = f"{table_id}_HDS_Snapshot"
-
         time_partitioning = {
             "type":hds_table_config.hds_table_time_partitioning.value,
             "field":hds_table_config.hds_metadata.partition_time_column_name,
             "expirationMs":partition_expiration
         }
-
     elif hds_table_config.hds_table_type == HdsTableType.SCD2:
-        table_id = f"{table_id}_HDS_SCD2"
-
         time_partitioning = None
-        
     else:
         raise AirflowException("Invalid HDS table type", hds_table_config.hds_table_type)
         
-    #1 Check if HDS table exists and if not create it using the provided schema file
-    create_table = BigQueryCreateEmptyTableOperator(
+    #1 Check if HDS table exists and if not create an empty table
+    create_table = CustomBigQueryCreateEmptyTableOperator(
         task_id="create_hds_table",
         project_id=project_id,
         dataset_id=dataset_id,
         table_id=table_id,
-        table_resource={
-                "schema":{'fields': schema_fields},
-                "timePartitioning":time_partitioning,
-                "encryptionConfiguration":encryption_configuration,
-                "labels":labels
-        },
-        exists_ok=True,
+        time_partitioning=time_partitioning,
         task_group=taskgroup,
         dag=dag
     )
@@ -78,7 +65,6 @@ def hds_builder(
         project_id=project_id,
         table_id=table_id,
         dataset_id=dataset_id, 
-        new_schema_fields=schema_fields,
         task_group=taskgroup,
         dag=dag
     )
@@ -93,7 +79,6 @@ def hds_builder(
         data_table_name=table_id,
         surrogate_keys=surrogate_keys,
         column_mapping=column_mapping,
-        columns=columns,
         ingestion_type=ingestion_type,
         hds_table_config=hds_table_config,
         task_group=taskgroup,

--- a/src/gcp_airflow_foundations/operators/gcp/ods/load_ods_taskgroup.py
+++ b/src/gcp_airflow_foundations/operators/gcp/ods/load_ods_taskgroup.py
@@ -1,8 +1,6 @@
 from airflow import DAG
 from airflow.exceptions import AirflowException
 
-from gcp_airflow_foundations.enums.ingestion_type import IngestionType
-
 from airflow.utils.task_group import TaskGroup
 
 from airflow.providers.google.cloud.operators.bigquery import (
@@ -13,6 +11,8 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from gcp_airflow_foundations.operators.gcp.ods.ods_merge_table_operator import MergeBigQueryODS
 from gcp_airflow_foundations.operators.gcp.schema_migration.schema_migration_operator import MigrateSchema
 
+from gcp_airflow_foundations.operators.gcp.create_table import CustomBigQueryCreateEmptyTableOperator
+
 
 def ods_builder(
     project_id,
@@ -21,8 +21,6 @@ def ods_builder(
     landing_zone_dataset,
     landing_zone_table_name_override,
     column_mapping,
-    columns,
-    schema_fields,
     surrogate_keys,
     ingestion_type,
     ods_table_config,
@@ -36,40 +34,27 @@ def ods_builder(
     """
     taskgroup = TaskGroup(group_id="create_ods_merge_taskgroup")
 
-    if ingestion_type == IngestionType.INCREMENTAL:
-        table_id = f"{table_id}_ODS_Incremental"
-
-    elif ingestion_type == IngestionType.FULL:
-        table_id = f"{table_id}_ODS_Full"
-
-    #1 Check if ODS table exists and if not create it using the provided schema file
-    create_table = BigQueryCreateEmptyTableOperator(
+    #1 Check if ODS table exists and if not create an empty table
+    create_table = CustomBigQueryCreateEmptyTableOperator(
         task_id="create_ods_table",
         project_id=project_id,
         dataset_id=dataset_id,
         table_id=table_id,
-        table_resource={
-                "schema":{'fields': schema_fields},
-                "timePartitioning":time_partitioning,
-                "encryptionConfiguration":encryption_configuration,
-                "labels":labels
-        },
-        exists_ok=True,
+        time_partitioning=None,
         task_group=taskgroup,
         dag=dag
     )
-
+    
     #2 Migrate schema
     migrate_schema = MigrateSchema(
         task_id="schema_migration",
         project_id=project_id,
         table_id=table_id,
         dataset_id=dataset_id, 
-        new_schema_fields=schema_fields,
         task_group=taskgroup,
         dag=dag
     )
-
+    
     #3 Merge or truncate tables based on the ingestion type defined in the config file and insert metadata columns
     insert = MergeBigQueryODS(
         task_id="insert_into_ods_table",
@@ -80,7 +65,6 @@ def ods_builder(
         data_table_name=table_id,
         surrogate_keys=surrogate_keys,
         column_mapping=column_mapping,
-        columns=columns,
         ingestion_type=ingestion_type,
         ods_table_config=ods_table_config,
         task_group=taskgroup,
@@ -89,4 +73,4 @@ def ods_builder(
 
     create_table >> migrate_schema >> insert
 
-    return taskgroup, table_id
+    return taskgroup

--- a/src/gcp_airflow_foundations/operators/gcp/ods/ods_merge_table_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/ods/ods_merge_table_operator.py
@@ -64,7 +64,6 @@ class MergeBigQueryODS(BigQueryOperator):
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = "google_cloud_default",
         column_mapping: dict,
-        columns: list,
         ingestion_type: IngestionType,
         ods_table_config: OdsTableConfig,
         **kwargs,
@@ -87,11 +86,12 @@ class MergeBigQueryODS(BigQueryOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.column_mapping = column_mapping
-        self.columns = columns
         self.ingestion_type = ingestion_type
         self.ods_table_config = ods_table_config
 
     def pre_execute(self, context) -> None:
+        columns = self.xcom_pull(context=context, task_ids="schema_parsing")['source_table_columns']
+
         self.log.info(
             f"Execute BigQueryMergeTableOperator {self.stg_table_name}, {self.data_table_name}"
         )
@@ -103,7 +103,7 @@ class MergeBigQueryODS(BigQueryOperator):
             target_dataset=self.data_dataset_name ,
             source=self.stg_table_name,
             target=self.data_table_name,
-            columns=self.columns,
+            columns=columns,
             surrogate_keys=self.surrogate_keys,
             column_mapping=self.column_mapping,
             ods_metadata=self.ods_table_config.ods_metadata

--- a/src/gcp_airflow_foundations/operators/gcp/schema_migration/schema_migration_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/schema_migration/schema_migration_operator.py
@@ -41,7 +41,6 @@ class MigrateSchema(BaseOperator):
         dataset_id,
         table_id,
         project_id, 
-        new_schema_fields,
         gcp_conn_id='google_cloud_default',
         delegate_to=None,
         encryption_configuration=None,
@@ -52,7 +51,6 @@ class MigrateSchema(BaseOperator):
         self.project_id = project_id
         self.dataset_id = dataset_id
         self.table_id = table_id
-        self.new_schema_fields = new_schema_fields 
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.encryption_configuration = encryption_configuration
@@ -65,6 +63,8 @@ class MigrateSchema(BaseOperator):
         self.cursor = conn.cursor()
 
     def execute(self, context):
+        self.new_schema_fields = self.xcom_pull(context=context, task_ids="schema_parsing")[self.table_id]
+
         query, schema_fields_updates, sql_columns, change_log = self.build_schema_query()
 
         if change_log:

--- a/src/gcp_airflow_foundations/operators/gcp/schema_parsing/schema_parsing_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/schema_parsing/schema_parsing_operator.py
@@ -29,22 +29,27 @@ class ParseSchema(BaseOperator):
         *,
         schema_config,
         column_mapping=None,
-        ods_table_config=None,
-        hds_table_config=None,
+        data_source=None,
+        table_config=None,
         **kwargs
     ) -> list:
         super().__init__(**kwargs)
 
         self.schema_config = schema_config
         self.column_mapping = column_mapping
-        self.ods_table_config = ods_table_config
-        self.hds_table_config = hds_table_config
+        self.data_source = data_source
+        self.table_config = table_config
+
+        self.ods_table_config = table_config.ods_config
+        self.hds_table_config = table_config.hds_config
 
     def execute(self, context):
 
-        schema_method = self.schema_config['method']
+        schema_source_config_class = self.schema_config
+        schema_method = schema_source_config_class().schema_method()
+        schema_method_arguments = schema_source_config_class().schema_method_arguments(self.data_source, self.table_config)
 
-        source_schema_fields = schema_method(**self.schema_config['kwargs'])
+        source_schema_fields = schema_method(**schema_method_arguments)
         logging.info(f"Parsed schema using: {schema_method}")
 
         schema_xcom = {'source_table_columns':[field["name"] for field in source_schema_fields]}

--- a/src/gcp_airflow_foundations/operators/gcp/schema_parsing/schema_parsing_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/schema_parsing/schema_parsing_operator.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+from airflow.models import BaseOperator, BaseOperatorLink
+from airflow.contrib.operators.bigquery_operator import (
+    BigQueryOperator,
+    BigQueryCreateEmptyTableOperator,
+)
+
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+
+from airflow.exceptions import AirflowException
+
+import logging
+
+from gcp_airflow_foundations.common.gcp.source_schema.gcs import read_schema_from_gcs
+from gcp_airflow_foundations.common.gcp.ods.schema_utils import parse_ods_schema
+from gcp_airflow_foundations.common.gcp.hds.schema_utils import parse_hds_schema
+
+
+from gcp_airflow_foundations.base_class.ods_table_config import OdsTableConfig
+from gcp_airflow_foundations.base_class.hds_table_config import HdsTableConfig
+
+
+class ParseSchema(BaseOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        schema_config,
+        column_mapping=None,
+        ods_table_config=None,
+        hds_table_config=None,
+        **kwargs
+    ) -> list:
+        super().__init__(**kwargs)
+
+        self.schema_config = schema_config
+        self.column_mapping = column_mapping
+        self.ods_table_config = ods_table_config
+        self.hds_table_config = hds_table_config
+
+    def execute(self, context):
+
+        schema_method = self.schema_config['method']
+
+        source_schema_fields = schema_method(**self.schema_config['kwargs'])
+        logging.info(f"Parsed schema using: {schema_method}")
+
+        schema_xcom = {'source_table_columns':[field["name"] for field in source_schema_fields]}
+
+        if self.column_mapping:
+                for field in source_schema_fields:
+                    if field["name"] in self.column_mapping.keys():
+                        field["name"] = self.column_mapping[field["name"]]
+
+        if self.ods_table_config:
+            schema_xcom[self.ods_table_config.table_id] = parse_ods_schema(
+                schema_fields=source_schema_fields,
+                ods_metadata=self.ods_table_config.ods_metadata
+            )
+
+        if self.hds_table_config:
+            schema_xcom[self.hds_table_config.table_id] = parse_hds_schema(
+                schema_fields=source_schema_fields,
+                hds_metadata=self.hds_table_config.hds_metadata,
+                hds_table_type=self.hds_table_config.hds_table_type
+            )
+
+        return schema_xcom

--- a/src/gcp_airflow_foundations/source_class/gcs_source.py
+++ b/src/gcp_airflow_foundations/source_class/gcs_source.py
@@ -15,7 +15,7 @@ class GCStoBQDagBuilder(DagBuilder):
     source_type = "GCS"
 
     def set_schema_method_type(self):
-        self.schema_source_type = SchemaSourceType.GCS
+        self.schema_source_type = self.config.source.schema_options.schema_source_type
 
     def get_bq_ingestion_task(self, table_config):
         # 1 Load CSV to BQ Landing Zone with schema auto-detection

--- a/src/gcp_airflow_foundations/source_class/gcs_source.py
+++ b/src/gcp_airflow_foundations/source_class/gcs_source.py
@@ -1,16 +1,11 @@
 import logging
 
 from airflow.models.dag import DAG
-from airflow.operators.python_operator import PythonOperator
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
-
-from gcp_airflow_foundations.base_class.data_source_table_config import DataSourceTablesConfig
 
 from gcp_airflow_foundations.source_class.source import DagBuilder
 
-from gcp_airflow_foundations.common.gcp.load_builder import load_builder
-
-from urllib.parse import urlparse
+from gcp_airflow_foundations.enums.schema_source_type import SchemaSourceType
 
 
 class GCStoBQDagBuilder(DagBuilder):
@@ -19,73 +14,25 @@ class GCStoBQDagBuilder(DagBuilder):
     """
     source_type = "GCS"
 
-    def build_dags(self):
+    def set_schema_method_type(self):
+        self.schema_source_type = SchemaSourceType.GCS
+
+    def get_bq_ingestion_task(self, table_config):
+        # 1 Load CSV to BQ Landing Zone with schema auto-detection
         data_source = self.config.source
-        logging.info(f"Building DAG for GCS {data_source.name}")
 
-        # gcs args
-        gcs_bucket = data_source.extra_options["gcs_bucket"]
-        gcs_objects = data_source.extra_options["gcs_objects"]
-        # bq args
-        landing_dataset = data_source.landing_zone_options.landing_zone_dataset
+        load_to_bq_landing = GCSToBigQueryOperator(
+            task_id='import_csv_to_bq_landing',
+            bucket=data_source.extra_options["gcs_bucket"],
+            source_objects=data_source.extra_options["gcs_objects"],
+            destination_project_dataset_table=f"{data_source.landing_zone_options.landing_zone_dataset}.{table_config.landing_zone_table_name_override}",
+            write_disposition='WRITE_TRUNCATE',
+            create_disposition='CREATE_IF_NEEDED',
+            skip_leading_rows=1
+        )
 
-        dags = []
-        for table_config in self.config.tables:
-            table_default_task_args = self.default_task_args_for_table(
-                self.config, table_config
-            )
-            logging.info(f"table_default_task_args {table_default_task_args}")
-
-            start_date = table_default_task_args["start_date"]
-
-            with DAG(
-                dag_id=f"gcs_to_bq_{data_source.name}",
-                description=f"BigQuery load for {table_config.table_name}",
-                schedule_interval=None,
-                default_args=table_default_task_args
-            ) as dag:
-
-                # 1 Load CSV to BQ Landing Zone
-                destination_table = f"{landing_dataset}.{table_config.landing_zone_table_name_override}"
-
-                parsed_url = urlparse(table_config.source_table_schema_object)
-                gcs_bucket = parsed_url.netloc
-                gcs_object = parsed_url.path.lstrip('/')
-
-                load_to_bq_landing = GCSToBigQueryOperator(
-                    task_id='import_csv_to_bq_landing',
-                    bucket=gcs_bucket,
-                    source_objects=gcs_objects,
-                    destination_project_dataset_table=destination_table,
-                    schema_object=gcs_object,
-                    write_disposition='WRITE_TRUNCATE',
-                    create_disposition='CREATE_IF_NEEDED',
-                    skip_leading_rows=1,
-                    dag=dag)
+        return load_to_bq_landing
              
-                #2 Create task groups for loading data to ODS/HDS tables
-                taskgroups = load_builder(
-                    project_id=data_source.gcp_project,
-                    table_id=table_config.table_name,
-                    dataset_id=data_source.dataset_data_name,
-                    landing_zone_dataset=landing_dataset,
-                    landing_zone_table_name_override=table_config.landing_zone_table_name_override,
-                    surrogate_keys=table_config.surrogate_keys,
-                    column_mapping=table_config.column_mapping,
-                    gcs_schema_object=table_config.source_table_schema_object,
-                    schema_fields=None,
-                    ingestion_type=table_config.ingestion_type,
-                    partition_expiration=data_source.partition_expiration,
-                    ods_table_config=table_config.ods_config,
-                    hds_table_config=table_config.hds_config,
-                    preceding_task=load_to_bq_landing,
-                    dag=dag
-                )
-
-                dags.append(dag)
-
-        return dags
-
     def validate_extra_options(self):
         # Example of extra validation to do
         extra_options = self.config.source.extra_options

--- a/src/gcp_airflow_foundations/source_class/gcs_source.py
+++ b/src/gcp_airflow_foundations/source_class/gcs_source.py
@@ -2,6 +2,7 @@ import logging
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from gcp_airflow_foundations.operators.gcp.gcs_to_bigquery import CustomGCSToBigQueryOperator
 
 from gcp_airflow_foundations.source_class.source import DagBuilder
 
@@ -21,8 +22,13 @@ class GCStoBQDagBuilder(DagBuilder):
         # 1 Load CSV to BQ Landing Zone with schema auto-detection
         data_source = self.config.source
 
-        load_to_bq_landing = GCSToBigQueryOperator(
+        schema_config = self.get_schema_method_class()
+
+        load_to_bq_landing = CustomGCSToBigQueryOperator(
             task_id='import_csv_to_bq_landing',
+            schema_config=schema_config,
+            data_source=data_source,
+            table_config=table_config,
             bucket=data_source.extra_options["gcs_bucket"],
             source_objects=data_source.extra_options["gcs_objects"],
             destination_project_dataset_table=f"{data_source.landing_zone_options.landing_zone_dataset}.{table_config.landing_zone_table_name_override}",

--- a/src/gcp_airflow_foundations/source_class/schema_source_config.py
+++ b/src/gcp_airflow_foundations/source_class/schema_source_config.py
@@ -1,0 +1,46 @@
+from abc import ABC, abstractmethod
+
+from gcp_airflow_foundations.common.gcp.source_schema.gcs import read_schema_from_gcs
+from gcp_airflow_foundations.common.gcp.source_schema.bq import read_schema_from_bq
+
+
+class SchemaSourceConfig(ABC):
+
+    @abstractmethod
+    def schema_method(self):
+        pass
+
+    @abstractmethod
+    def schema_method_arguments(self, data_source, table_config):
+        pass
+
+class AutoSchemaSourceConfig(SchemaSourceConfig):
+
+    def schema_method(self):
+        return
+
+    def schema_method_arguments(self, data_source, table_config):
+        return
+
+
+class GCSSchemaSourceConfig(SchemaSourceConfig):
+
+    def schema_method(self):
+        return read_schema_from_gcs
+
+    def schema_method_arguments(self, data_source, table_config):
+        return {
+                'gcs_schema_object':data_source.schema_options.schema_object_template.format(table_name=table_config.table_name)
+            }
+
+
+class BQLandingZoneSchemaSourceConfig(SchemaSourceConfig):
+
+    def schema_method(self):
+        return read_schema_from_bq
+
+    def schema_method_arguments(self, data_source, table_config):
+        return {
+                'dataset_id':data_source.landing_zone_options.landing_zone_dataset, 
+                'table_id':table_config.landing_zone_table_name_override
+            }

--- a/src/gcp_airflow_foundations/source_class/source.py
+++ b/src/gcp_airflow_foundations/source_class/source.py
@@ -1,8 +1,17 @@
 from abc import ABC, abstractmethod, abstractproperty
 
+from airflow.models.dag import DAG
+
 from gcp_airflow_foundations.base_class.data_source_table_config import DataSourceTablesConfig
 from gcp_airflow_foundations.base_class.source_table_config import SourceTableConfig
 
+from gcp_airflow_foundations.enums.schema_source_type import SchemaSourceType
+from gcp_airflow_foundations.common.gcp.source_schema.gcs import read_schema_from_gcs
+from gcp_airflow_foundations.common.gcp.source_schema.bq import read_schema_from_bq
+
+from gcp_airflow_foundations.common.gcp.load_builder import load_builder
+
+import logging
 
 class DagBuilder(ABC):
     """
@@ -24,15 +33,95 @@ class DagBuilder(ABC):
         self.default_task_args = default_task_args
         self.config = config
         self.validate_extra_options()
+        self.set_schema_method_type()
+        self.schema_method = self.get_schema_method()
+        self.validate_custom_method()
         super().__init__()
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         cls.sources.append(cls)
 
-    @abstractmethod
     def build_dags(self):
+        data_source = self.config.source
+        logging.info(f"Building DAG for {data_source.name}")
+
+        dags = []
+        for table_config in self.config.tables:
+            table_default_task_args = self.default_task_args_for_table(
+                self.config, table_config
+            )
+            logging.info(f"table_default_task_args {table_default_task_args}")
+
+            start_date = table_default_task_args["start_date"]
+
+            with DAG(
+                dag_id=f"gcs_to_bq_{data_source.name}",
+                description=f"BigQuery load for {table_config.table_name}",
+                schedule_interval=None,
+                default_args=table_default_task_args
+            ) as dag:    
+
+                load_to_bq_landing = self.get_bq_ingestion_task(table_config)
+                load_to_bq_landing.dag = dag
+
+                self.get_datastore_ingestion_task(dag, load_to_bq_landing, data_source, table_config)
+            
+            dags.append(dag)
+
+        return dags
+
+    @abstractmethod
+    def get_bq_ingestion_task(self, table_config):
         pass
+
+    def get_datastore_ingestion_task(self, dag, preceding_task, data_source, table_config):
+        load_builder(
+            project_id=data_source.gcp_project,
+            table_id=table_config.table_name,
+            dataset_id=data_source.dataset_data_name,
+            landing_zone_dataset=data_source.landing_zone_options.landing_zone_dataset,
+            landing_zone_table_name_override=table_config.landing_zone_table_name_override,
+            surrogate_keys=table_config.surrogate_keys,
+            column_mapping=table_config.column_mapping,
+            schema_config=self.get_schema_method_args(table_config),
+            ingestion_type=table_config.ingestion_type,
+            partition_expiration=data_source.partition_expiration,
+            ods_table_config=table_config.ods_config,
+            hds_table_config=table_config.hds_config,
+            preceding_task=preceding_task,
+            dag=dag
+        )
+
+    @abstractmethod
+    def set_schema_method_type(self):
+        pass
+
+    def get_schema_method(self):
+        if self.schema_source_type == SchemaSourceType.GCS:
+            for table_config in self.config.tables:
+                assert table_config.source_table_schema_object is not None, f'GCS Schema Object URI must be provided for table {table_config.table_name}'
+            return read_schema_from_gcs
+
+        elif self.schema_source_type == SchemaSourceType.LANDINGZONE:
+            return read_schema_from_bq
+
+    def get_schema_method_args(self, table_config):
+        if self.schema_source_type == SchemaSourceType.GCS:
+            return {
+                'method':self.schema_method,
+                'kwargs':{'gcs_schema_object':table_config.source_table_schema_object}
+            }
+
+        elif self.schema_source_type == SchemaSourceType.LANDINGZONE:  
+            return {
+                'method':self.schema_method,
+                'kwargs':{'staging_dataset_id':self.config.source.landing_zone_options.landing_zone_dataset, 'staging_table_id':table_config.landing_zone_table_name_override}
+            }
+
+    def validate_custom_method(self):
+        if self.set_schema_method_type() == SchemaSourceType.CUSTOM:
+            assert self.get_schema_method() is not None, 'A custom method for schema parsing must be provided'
 
     @abstractmethod
     def validate_extra_options(self):


### PR DESCRIPTION
Changes:
- Refactored DagBuilder Class to have ```get_bq_ingestion_task``` and ```get_datastore_ingestion_task``` method that can be overridden in the Source Class. These methods return the pre- and post-landing zone ingestion tasks respectively. The ```get_bq_ingestion_task``` method is abstract and must be provided in each Source class.
- Added ```get_schema_method``` and ```get_schema_method_args``` methods. Both can be overridden if a user wants to provide a custom schema method.
- Added ParseSchema operator that reads schema using the provided method and writes to xcom for the rest of the operators to use
- Refactored existing operators to read schema from xcom
- Added SchemaSourceType enum
- Added ```read_schema_from_bq``` method to read schema from another BQ table

Resolves Jira issue: AF-43