### PR TITLE
wait_until_finished option for Dataform operator & hook

### DIFF
--- a/gcp_airflow_foundations/operators/api/hooks/dataform_hook.py
+++ b/gcp_airflow_foundations/operators/api/hooks/dataform_hook.py
@@ -22,6 +22,8 @@ class DataformHook(BaseHook):
     :type schedule: str
     :param tags: (optional) A list of tags with which the action must have in order to be run. If not set, then all actions will run.
     :type tags: list[str]
+    :param wait_until_finished: (optional) wait until job finishes running, either return success or error
+    :type wait_until_finished: bool
 
     Instructions to prepare Dataform for the API call:
     1. create schedule in Dataform for REST API call
@@ -47,7 +49,7 @@ class DataformHook(BaseHook):
         self.project_id = self.conn.login
         self.api_key = self.conn.password
 
-    def run_job(self, environment: str, schedule: str, tags: Optional[str] = []) -> str:
+    def run_job(self, environment: str, schedule: str, tags: Optional[str] = [], wait_until_finished: bool = True) -> str:
         base_url = f'https://api.dataform.co/v1/project/{self.project_id}/run'
         headers = {'Authorization': f'Bearer {self.api_key}'}
         run_create_request = {
@@ -67,16 +69,15 @@ class DataformHook(BaseHook):
         except Exception:
             raise AirflowException(f"Dataform ApiService Error: {response.json()}")
 
-        response = requests.get(run_url, headers=headers)
-
-        while response.json()['status'] == 'RUNNING':
-            time.sleep(10)
-            # retry after 10 seconds
+        while wait_until_finished:
             response = requests.get(run_url, headers=headers)
-            logging.info(response.json())
 
-        if response.json()['status'] == 'SUCCESSFUL':
-            return f"Dataform run completed: SUCCESSFUL see run logs at {response.json()['runLogUrl']}"
-        else:
-            raise AirflowException(
-                f"Dataform run {response.json()['status']} for {response.json()['id']}: see run logs at {response.json()['runLogUrl']}")
+            if response.json()['status'] == 'RUNNING':
+                response = requests.get(run_url, headers=headers)
+                logging.info(f'Dataform run in progress: {response.json()}')
+                time.sleep(10)
+            elif response.json()['status'] == 'SUCCESSFUL':
+                return f"Dataform run completed: SUCCESSFUL see run logs at {response.json()['runLogUrl']}"
+            else:
+                raise AirflowException(
+                    f"Dataform run {response.json()['status']} for {response.json()['id']}: see run logs at {response.json()['runLogUrl']}")

--- a/gcp_airflow_foundations/operators/api/hooks/dataform_hook.py
+++ b/gcp_airflow_foundations/operators/api/hooks/dataform_hook.py
@@ -22,8 +22,10 @@ class DataformHook(BaseHook):
     :type schedule: str
     :param tags: (optional) A list of tags with which the action must have in order to be run. If not set, then all actions will run.
     :type tags: list[str]
-    :param wait_until_finished: (optional) wait until job finishes running, either return success or error
+    :param wait_until_finished: (optional) ait until job finishes running, either return success or error
     :type wait_until_finished: bool
+    :param sleep_time: (optional) if status returns "RUNNING", wait for configured time before retry. Default is 60 seconds
+    :type sleep_time: int
 
     Instructions to prepare Dataform for the API call:
     1. create schedule in Dataform for REST API call
@@ -49,7 +51,7 @@ class DataformHook(BaseHook):
         self.project_id = self.conn.login
         self.api_key = self.conn.password
 
-    def run_job(self, environment: str, schedule: str, tags: Optional[str] = [], wait_until_finished: bool = True) -> str:
+    def run_job(self, environment: str, schedule: str, tags: Optional[str] = [], wait_until_finished: bool = True, sleep_time: int = 60) -> str:
         base_url = f'https://api.dataform.co/v1/project/{self.project_id}/run'
         headers = {'Authorization': f'Bearer {self.api_key}'}
         run_create_request = {
@@ -75,7 +77,7 @@ class DataformHook(BaseHook):
             if response.json()['status'] == 'RUNNING':
                 response = requests.get(run_url, headers=headers)
                 logging.info(f'Dataform run in progress: {response.json()}')
-                time.sleep(10)
+                time.sleep(sleep_time)
             elif response.json()['status'] == 'SUCCESSFUL':
                 return f"Dataform run completed: SUCCESSFUL see run logs at {response.json()['runLogUrl']}"
             else:

--- a/gcp_airflow_foundations/operators/api/operators/dataform_operator.py
+++ b/gcp_airflow_foundations/operators/api/operators/dataform_operator.py
@@ -16,6 +16,8 @@ class DataformOperator(BaseOperator):
     :type schedule: str
     :param tags: (optional) A list of tags with which the action must have in order to be run. If not set, then all actions will run.
     :type tags: list[str]
+    :param wait_until_finished: (optional) wait until job finishes running, either return success or error
+    :type wait_until_finished: bool
 
     Instructions to prepare Dataform for the API call:
     1. create schedule in Dataform for REST API call
@@ -34,17 +36,19 @@ class DataformOperator(BaseOperator):
     ** Note: Schedules must be on the master branch. In Dataform, you'll have to create a branch first and then merge changes into master.
     '''
     @apply_defaults
-    def __init__(self, *, dataform_conn_id: str = 'dataform_default', environment: str, schedule: str, tags: Optional[str] = [], **kwargs: Any) -> None:
+    def __init__(self, *, dataform_conn_id: str = 'dataform_default', environment: str, schedule: str, tags: Optional[str] = [], wait_until_finished: bool = True, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.dataform_conn_id = dataform_conn_id
         self.environment = environment
         self.schedule = schedule
         self.tags = tags
+        self.wait_until_finished = wait_until_finished
 
     def execute(self, context) -> str:
         dataform_hook = DataformHook(dataform_conn_id=self.dataform_conn_id)
         dataform_hook.run_job(
             environment=self.environment,
             schedule=self.schedule,
-            tags=self.tags
+            tags=self.tags,
+            wait_until_finished=self.wait_until_finished
         )


### PR DESCRIPTION
if wait_until_finished is True (default): wait until task returns success or error. Therefore if status is 'running', sleep 10 and try again.
if wait_until_finished is False: airflow task returns success after job is sent. Does not wait for job completion.