### PR TITLE
added support for source level dags/regex matching

### DIFF
--- a/src/gcp_airflow_foundations/base_class/source_ingestion_config.py
+++ b/src/gcp_airflow_foundations/base_class/source_ingestion_config.py
@@ -1,0 +1,22 @@
+from dacite import Config
+from pydantic import validator, root_validator
+from pydantic.dataclasses import dataclass
+
+from typing import List, Optional
+import regex as re
+
+from gcp_airflow_foundations.enums.schema_source_type import SchemaSourceType
+
+@dataclass
+class FullIngestionConfig:
+    """
+    Attributes:
+        ingest_all_tables: if true, ingest all tables from source
+        dag_creation_mode: if "SOURCE", then one DAG per source is created. if "TABLE", one DAG per table.
+        partition_name: name to use for DAG id, should correspond to the relevant partition of the source cut out by the regex expression provided
+        regex_table_matching: regex pattern to match tables to, if ingest_all_tables is false
+    """
+    ingest_all_tables: bool = False
+    dag_creation_mode: str = "TABLE"
+    partition_name: str = ""
+    regex_table_pattern: str = "ANY"

--- a/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/hds/hds_merge_table_operator.py
@@ -65,11 +65,13 @@ class MergeBigQueryHDS(BigQueryOperator):
         data_table_name: str,
         stg_dataset_name: str,
         data_dataset_name: str,
+        schema_parsing_task_id: str,
         surrogate_keys: [str],
         columns: Optional[list] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = "google_cloud_default",
         column_mapping: dict,
+        column_casting: dict,
         ingestion_type: IngestionType,
         hds_table_config: HdsTableConfig,
         location: Optional[str] = None,
@@ -91,17 +93,19 @@ class MergeBigQueryHDS(BigQueryOperator):
         self.data_table_name = data_table_name
         self.stg_dataset_name = stg_dataset_name
         self.data_dataset_name = data_dataset_name
+        self.schema_parsing_task_id = schema_parsing_task_id
         self.surrogate_keys = surrogate_keys
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.columns = columns
         self.column_mapping = column_mapping
+        self.column_casting = column_casting
         self.ingestion_type = ingestion_type
         self.hds_table_config = hds_table_config
 
     def pre_execute(self, context) -> None:
         if not self.columns:
-            staging_columns = self.xcom_pull(context=context, task_ids="schema_parsing")['source_table_columns']
+            staging_columns = self.xcom_pull(context=context, task_ids=self.schema_parsing_task_id)['source_table_columns']
         else:
             staging_columns = self.columns
 
@@ -132,6 +136,7 @@ class MergeBigQueryHDS(BigQueryOperator):
             columns=source_columns,
             surrogate_keys=self.surrogate_keys,
             column_mapping=self.column_mapping,
+            column_casting=self.column_casting,
             hds_metadata=self.hds_table_config.hds_metadata
         )
 

--- a/src/gcp_airflow_foundations/operators/gcp/schema_migration/schema_migration_operator.py
+++ b/src/gcp_airflow_foundations/operators/gcp/schema_migration/schema_migration_operator.py
@@ -7,7 +7,7 @@ from airflow.contrib.operators.bigquery_operator import (
 )
 
 from airflow.utils.decorators import apply_defaults
-from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 
 from airflow.exceptions import AirflowException
 
@@ -38,9 +38,10 @@ class MigrateSchema(BaseOperator):
     def __init__(
         self,
         *,
+        schema_parsing_task_id,
         dataset_id,
         table_id,
-        project_id, 
+        project_id,
         new_schema_fields=None,
         gcp_conn_id='google_cloud_default',
         delegate_to=None,
@@ -50,6 +51,7 @@ class MigrateSchema(BaseOperator):
         super().__init__(**kwargs)
 
         self.project_id = project_id
+        self.schema_parsing_task_id = schema_parsing_task_id
         self.dataset_id = dataset_id
         self.table_id = table_id
         self.new_schema_fields = new_schema_fields
@@ -66,7 +68,7 @@ class MigrateSchema(BaseOperator):
 
     def execute(self, context):
         if not self.new_schema_fields:
-            self.new_schema_fields = self.xcom_pull(context=context, task_ids="schema_parsing")[self.table_id]
+            self.new_schema_fields = self.xcom_pull(context=context, task_ids=self.schema_parsing_task_id)[self.table_id]
 
         query, schema_fields_updates, sql_columns, change_log = self.build_schema_query()
 
@@ -74,7 +76,7 @@ class MigrateSchema(BaseOperator):
             logging.info("Migrating new schema to target table")
 
             if sql_columns:
-                self.cursor.run_query(
+                self.hook.run_query(
                     sql=query,
                     use_legacy_sql=False,
                     destination_dataset_table=f"{self.dataset_id}.{self.table_id}",
@@ -113,7 +115,7 @@ class MigrateSchema(BaseOperator):
         :rtype: list
         """
 
-        self.current_schema_fields = self.cursor.get_schema(dataset_id=self.dataset_id, table_id=self.table_id).get("fields", None)
+        self.current_schema_fields = self.hook.get_schema(dataset_id=self.dataset_id, table_id=self.table_id).get("fields", None)
         
         logging.info(f"The current schema is: {self.current_schema_fields}")
 
@@ -188,7 +190,7 @@ class MigrateSchema(BaseOperator):
                 )
 
                 schema_fields_updates.append(
-                    {"name":column_name,"mode":"NULLABLE","type":column_type}
+                   field
                 )
 
         query = f"""SELECT {",".join(sql_columns)} FROM `{self.dataset_id}.{self.table_id}`;"""

--- a/src/gcp_airflow_foundations/source_class/jdbc_dataflow_source.py
+++ b/src/gcp_airflow_foundations/source_class/jdbc_dataflow_source.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod, abstractproperty
 import logging
 from re import A
 import re
+from airflow.operators.dummy import DummyOperator
 from dacite import from_dict
 from dataclasses import dataclass
 
@@ -23,6 +24,8 @@ from airflow.providers.google.cloud.operators.bigquery import BigQueryCreateEmpt
 from airflow.providers.google.cloud.hooks.kms import CloudKMSHook
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.models import Variable
+from airflow.operators.subdag import SubDagOperator
+
 from gcp_airflow_foundations.common.dataflow.jdbc.dataflow_taskgroups import dataflow_taskgroup_builder
 
 from gcp_airflow_foundations.base_class.data_source_table_config import DataSourceTablesConfig
@@ -35,7 +38,11 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
     source_type = "JDBC"
 
     def get_extra_dags(self):
-        return [self.get_schema_dag()]
+        schema_dag = self.get_schema_dag()
+        if schema_dag:
+            return [schema_dag]
+        else:
+            return schema_dag
 
     def set_schema_method_type(self):
         self.schema_source_type = self.config.source.schema_options.schema_source_type     
@@ -51,9 +58,12 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
         # Table level parameters
         dataflow_job_params = data_source.extra_options["dataflow_job_config"]
         schema_table = dataflow_job_params["bq_schema_table"]
+        ingest_metadata = dataflow_job_params["ingest_metadata"]
         table_name = table_config.landing_zone_table_name_override
         destination_table = f"{gcp_project}:{landing_dataset}.{table_name}"
         destination_schema_table = f"{gcp_project}.{landing_dataset}.{schema_table}"
+
+        table_type_casts = data_source.extra_options["dataflow_job_config"]["table_type_casts"]
 
         taskgroup = dataflow_taskgroup_builder(
             query_schema=False,
@@ -64,7 +74,9 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
             system_name=system_name,
             create_job_params=self.create_job_params,
             run_dataflow_job=self.run_dataflow_job,
-            create_table=self.create_table
+            create_table=self.create_table,
+            ingest_metadata=ingest_metadata,
+            table_type_casts=table_type_casts
         )
 
         return taskgroup
@@ -78,35 +90,40 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
         landing_dataset = data_source.landing_zone_options.landing_zone_dataset
 
         dataflow_job_params = data_source.extra_options["dataflow_job_config"]
-
+        ingest_metadata = dataflow_job_params["ingest_metadata"]
         schema_table_name = dataflow_job_params["bq_schema_table"]
         destination_table = f"{gcp_project}:{landing_dataset}.{schema_table_name}"
         system_name = dataflow_job_params["system_name"]
 
-        with DAG(
-            dag_id=f"{system_name}_upload_schema",
-            description=f"Upload source schemas for all tables to BQ",
-            schedule_interval="@daily",
-            default_args=self.default_task_args_for_table(
-                self.config, self.config.tables[0]
-            )
-        ) as schema_dag:
+        if ingest_metadata:
+            with DAG(
+                dag_id=f"{system_name}_upload_schema",
+                description=f"Upload source schemas for all tables to BQ",
+                schedule_interval="@daily",
+                default_args=self.default_task_args_for_table(
+                    self.config, self.config.tables[0]
+                )
+            ) as schema_dag:
 
-            taskgroup = dataflow_taskgroup_builder(
-              #  schema_dag,
-                query_schema=True,
-                dataflow_job_params=dataflow_job_params,
-                destination_table=destination_table,
-                destination_schema_table=f"{gcp_project}.{landing_dataset}.{schema_table_name}",
-                table_name=schema_table_name,
-                system_name=system_name,
-                create_job_params=self.create_job_params,
-                run_dataflow_job=self.run_dataflow_job,
-                create_table=self.create_table
-            )
-            taskgroup.dag = schema_dag
+                taskgroup = dataflow_taskgroup_builder(
+                #  schema_dag,
+                    query_schema=True,
+                    dataflow_job_params=dataflow_job_params,
+                    destination_table=destination_table,
+                    destination_schema_table=f"{gcp_project}.{landing_dataset}.{schema_table_name}",
+                    table_name=schema_table_name,
+                    system_name=system_name,
+                    create_job_params=self.create_job_params,
+                    run_dataflow_job=self.run_dataflow_job,
+                    create_table=self.create_table,
+                    ingest_metadata=ingest_metadata,
+                    table_type_casts={}
+                )
+                taskgroup.dag = schema_dag
 
-            return schema_dag
+                return schema_dag
+        else:
+            return
 
     def run_dataflow_job(self, template_path, system_name, table_name, query_schema, **kwargs):
         ti = kwargs['ti']
@@ -129,18 +146,25 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
         )
         trigger_job.execute(context=kwargs)
     
-    def create_table(self, destination_table, schema_table, source_table, **kwargs):
+    def create_table(self, destination_table, schema_table, source_table, table_type_casts, **kwargs):
         ds = kwargs["ds"]
         ids = destination_table.split(":")
         project_id = ids[0]
         dataset_id = ids[1].split(".")[0]
         table_id = ids[1].split(".")[1] + f"_{ds}"
 
-        logging.info(ids)
+        logging.info(destination_table)
+
         bq_hook = BigQueryHook()
         table_exists = bq_hook.table_exists(dataset_id=dataset_id, table_id=table_id)
+        logging.info(table_exists)
 
         schema_fields = self.get_landing_schema(schema_table, source_table)
+
+        for key in table_type_casts:
+            for i in range(len(schema_fields)):
+                if schema_fields[i]["type"] == key:
+                    schema_fields[i]["type"] = table_type_casts[key]
         logging.info(schema_fields)
 
         if not table_exists:
@@ -183,6 +207,29 @@ class JdbcToBQDataflowDagBuilder(DagBuilder):
            query
         """
         pass
+
+    def get_source_tables_to_ingest(self):
+
+        data_source = self.config.source
+        gcp_project = data_source.gcp_project
+        landing_dataset = data_source.landing_zone_options.landing_zone_dataset
+
+        dataflow_job_params = data_source.extra_options["dataflow_job_config"]
+        schema_table = dataflow_job_params["bq_schema_table"]
+
+        destination_schema_table = f"{gcp_project}.{landing_dataset}.{schema_table}"
+
+        bq_hook = BigQueryHook()
+        sql = f"SELECT DISTINCT TABLE_NAME FROM `{destination_schema_table}`"   
+        table_list = bq_hook.get_pandas_df(sql=sql, dialect="standard").iloc[:,0]
+
+        # match regex
+        if not data_source.full_ingestion_options.regex_table_pattern == "ANY":
+            regex_pattern = data_source.full_ingestion_options.regex_table_pattern
+            r = re.compile(regex_pattern)
+            table_list = list(filter(r.match, table_list))
+
+        return table_list
 
     @abstractmethod
     def get_landing_schema(self, schema_table, source_table):

--- a/src/gcp_airflow_foundations/source_class/oracle_dataflow_source.py
+++ b/src/gcp_airflow_foundations/source_class/oracle_dataflow_source.py
@@ -1,6 +1,7 @@
 from dataclasses import fields
 from urllib.parse import urlparse
 import logging
+import re
 
 from airflow.models.dag import DAG
 from airflow.operators.python_operator import PythonOperator
@@ -9,6 +10,7 @@ from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.providers.google.cloud.hooks.kms import CloudKMSHook
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.models import Variable
+from airflow.utils.task_group import TaskGroup
 
 from gcp_airflow_foundations.source_class.jdbc_dataflow_source import JdbcToBQDataflowDagBuilder
 from gcp_airflow_foundations.base_class.data_source_table_config import DataSourceTablesConfig
@@ -20,7 +22,7 @@ class OracleToBQDataflowDagBuilder(JdbcToBQDataflowDagBuilder):
     """
     Builds DAGs to load a CSV file from GCS to a BigQuery Table.
     """
-    source_type = "ORACLE"
+    source_type = "ORACLE"  
 
     def create_job_params(self, config_params, destination_table, table_name, destination_schema_table, query_schema, owner, **kwargs):
         #   1.  Generate SQL Query

--- a/src/gcp_airflow_foundations/source_class/source.py
+++ b/src/gcp_airflow_foundations/source_class/source.py
@@ -1,9 +1,12 @@
 from abc import ABC, abstractmethod, abstractproperty
 
 from airflow.models.dag import DAG
+from airflow.utils.task_group import TaskGroup
+import copy
 
 from gcp_airflow_foundations.base_class.data_source_table_config import DataSourceTablesConfig
 from gcp_airflow_foundations.base_class.source_table_config import SourceTableConfig
+from gcp_airflow_foundations.base_class.source_config import SourceConfig
 from gcp_airflow_foundations.enums.schema_source_type import SchemaSourceType
 from gcp_airflow_foundations.common.gcp.load_builder import load_builder
 from gcp_airflow_foundations.source_class.schema_source_config import AutoSchemaSourceConfig, GCSSchemaSourceConfig, BQLandingZoneSchemaSourceConfig
@@ -11,11 +14,14 @@ from gcp_airflow_foundations.source_class.schema_source_config import AutoSchema
 import logging
 
 class DagBuilder(ABC):
-    """
-    A base DAG builder for creating a list of DAGs for a given source.
-    Attributes:
-        sources:              List of initialized subclasses of this class (dynamically updated during runtime)
-        config:               DataSourceTablesConfig object for DAG configuration
+    """A base DAG builder for creating a list of DAGs for a given source.
+
+    Attributes
+    ----------
+    sources : list(DagBuilder)
+        List of initialized subclasses of this class (dynamically updated during runtime)
+    config : DataSourceTablesConfig
+        DAG configuration object
     """
     sources = []
 
@@ -34,8 +40,26 @@ class DagBuilder(ABC):
         cls.sources.append(cls)
 
     def build_dags(self):
+        """
+        Main DAG building method
+        """
         data_source = self.config.source
         logging.info(f"Building DAG for {data_source.name}")
+
+        if data_source.regex_matching:
+            full_ingestion_options = data_source.full_ingestion_options
+            if full_ingestion_options.dag_creation_mode == "SOURCE":
+                return self.build_dags_source_level()
+            else:
+                table_names = self.get_source_tables_to_ingest()
+                templated_table_config = self.config.tables[0]
+                new_table_configs = []
+                # populate list of copies of the templated config
+                for table_name in table_names:
+                    config_copy = copy.deepcopy(templated_table_config)
+                    config_copy.table_name = table_name
+                    new_table_configs.append(config_copy)
+                self.config.tables = new_table_configs
 
         dags = []
         for table_config in self.config.tables:
@@ -45,40 +69,107 @@ class DagBuilder(ABC):
             logging.info(f"table_default_task_args {table_default_task_args}")
 
             start_date = table_default_task_args["start_date"]
-
+            
+            kwargs = data_source.dag_args if data_source.dag_args else {}
+            
             with DAG(
-                dag_id=f"{data_source.name}_to_bq_{table_config.table_name}",
+                dag_id=f"{data_source.name}.{table_config.table_name}",
                 description=f"{data_source.name} to BigQuery load for {table_config.table_name}",
                 schedule_interval=data_source.ingest_schedule,
                 default_args=table_default_task_args,
-                render_template_as_native_obj=True
+                render_template_as_native_obj=True,
+                **kwargs
             ) as dag:    
 
-                load_to_bq_landing = self.get_bq_ingestion_task(dag, table_config)
-
-                self.get_datastore_ingestion_task(dag, load_to_bq_landing, data_source, table_config)
-            
+                self.set_task_dependencies(dag, table_config, data_source, "schema_parsing")
                 dags.append(dag)
-                
-        dags = dags + self.get_extra_dags()
+
+        extra_dags=  self.get_extra_dags()
+
+        if extra_dags is not None and not extra_dags == []:
+            dags = dags + self.get_extra_dags()
+
         return dags
 
+    def build_dags_source_level(self):
+        """
+        Build one DAG per source for regex matching or full source ingestion 
+        """
+        data_source = self.config.source
+
+        logging.info(f"Building DAG for {data_source.name}")
+
+        dags = []
+        tables = self.get_source_tables_to_ingest()
+
+        # one template table config is filled out for the entire source
+        templated_table_config = self.config.tables[0]
+        table_default_task_args = self.default_task_args_for_table(
+            self.config, templated_table_config
+        )
+        logging.info(f"table_default_task_args {table_default_task_args}")
+
+        start_date = table_default_task_args["start_date"]
+        
+        kwargs = data_source.dag_args if data_source.dag_args else {}
+        
+        with DAG(
+            dag_id=f"{data_source.name}.{data_source.full_ingestion_options.partition_name}",
+            description=f"{data_source.name} to BigQuery load",
+            schedule_interval=data_source.ingest_schedule,
+            default_args=table_default_task_args,
+            render_template_as_native_obj=True,
+            **kwargs
+        ) as dag:    
+            
+            for table_name in tables:
+                table_config = templated_table_config
+                table_config.table_name = table_name
+
+                schema_parsing_task_id = "schema_parsing"
+                if data_source.full_ingestion_options.dag_creation_mode == "SOURCE":
+                    schema_parsing_task_id = f"{table_config.table_name}.{schema_parsing_task_id}"
+                
+                with TaskGroup(group_id=table_config.table_name) as table_task_group:
+                    self.set_task_dependencies(dag, table_config, data_source, schema_parsing_task_id)
+                table_task_group
+            
+            dags.append(dag)
+        extra_dags=  self.get_extra_dags()
+
+        if extra_dags is not None and not extra_dags == []:
+            dags = dags + self.get_extra_dags()
+
+        return dags
+
+    def set_task_dependencies(self, dag: DAG, table_config: SourceTableConfig, data_source: SourceConfig, schema_parsing_task_id: str):
+        load_to_bq_landing = self.get_bq_ingestion_task(dag, table_config)
+        datastore_ingestion_tasks = self.get_datastore_ingestion_task(dag, load_to_bq_landing, data_source, table_config, schema_parsing_task_id)
+        # hacky fix right now 
+        # TO-DO: get this working in the load_builder class (isn't working there currently)
+        load_to_bq_landing >> datastore_ingestion_tasks[0]
+        for i in range(len(datastore_ingestion_tasks) - 1):
+            datastore_ingestion_tasks[i] >> datastore_ingestion_tasks[i+1]
+
     @abstractmethod
-    def get_bq_ingestion_task(self, table_config):
+    def get_bq_ingestion_task(self, table_config: SourceTableConfig):
+        """Abstract method for the Airflow task that ingests data to the BigQuery staging table"""
         pass
 
-    def get_datastore_ingestion_task(self, dag, preceding_task, data_source, table_config):
-        load_builder(
+    def get_datastore_ingestion_task(self, dag, preceding_task, data_source: SourceConfig, table_config:SourceTableConfig, schema_parsing_task_id: str):
+        """Method for the Airflow task group that upserts data to the ODS and HDS tables"""
+        return load_builder(
             data_source=data_source,
             table_config=table_config,
             schema_config=BQLandingZoneSchemaSourceConfig,
             preceding_task=preceding_task,
+            schema_parsing_task_id=schema_parsing_task_id,
             dag=dag
         )
 
     def get_extra_dags(self):
-    # Override if non-table ingestion DAGs are needed for the flow: return them here
-        return []
+        # Override if non-table ingestion DAGs are needed for the flow: return them here
+        return []   
 
     @abstractmethod
     def set_schema_method_type(self):


### PR DESCRIPTION
PR to get source level DAGS working.

Options are either for  
1. regular table configs (set regex_matching = False...think of better name?)
2. table level DAGs for full source ingestion (regex_matching = True, dag_creation_mode = TABLE in the FullIngestionConfig)
3. source level DAGs for full source ingestion (regex_matching = True, dag_creation_mode = SOURCE in the FullIngestionConfig)

any source should optionally expose a method get_source_tables_to_ingest() that fetches a list of tables to ingest (either a full list, or filters by the regex_table_pattern field). Example in the jdbc_dataflow_source class. 

Some of the changes are weirdly wrapped up with some older changes in the ods/hds taskgroups, so pay those no mind. 