### PR TITLE
Replace success

### DIFF
--- a/gcp_airflow_foundations/common/gcp/load_builder.py
+++ b/gcp_airflow_foundations/common/gcp/load_builder.py
@@ -126,7 +126,7 @@ def load_builder(
     else:
         preceding_task >> parse_schema >> ods_task_group >> delete_staging_table
 
-    done = DummyOperator(task_id="done", trigger_rule=TriggerRule.ALL_DONE)
+    done = DummyOperator(task_id="done", trigger_rule=TriggerRule.ALL_SUCCESS)
 
     if dlp_table_config.get_is_on():
 


### PR DESCRIPTION
Considering the airflow documentation and ticket from Eyereturn,
The last task in the DAG is a dummy operator and display a GREEN color in airflow UI whenever all the tasks ran.
However it does not consider if the tasks are successful, hence we can follow Airflow doc and add ALL_SUCCESS instead
https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html#concepts-trigger-rules