### PR TITLE
added allow_jagged_rows=True and allow_quoted_newlines=True

### DIFF
--- a/gcp_airflow_foundations/source_class/salesforce_source.py
+++ b/gcp_airflow_foundations/source_class/salesforce_source.py
@@ -99,6 +99,8 @@ class SalesforcetoBQDagBuilder(DagBuilder):
             destination_project_dataset_table=destination_table + f"_{ds}",
             write_disposition="WRITE_TRUNCATE",
             create_disposition="CREATE_IF_NEEDED",
+            allow_jagged_rows=True,
+            allow_quoted_newlines=True,
             skip_leading_rows=1,
         )
         load_to_bq.execute(context=kwargs)


### PR DESCRIPTION
Currently, when creating BigQuery table(s) from GCS file(s), if any of the GCS file has a newline character or if a row is empty, the record(s) is treated as bad and the BigQuery table cannot be created

To allow missing values to be treated as 'null' and records encased in quotation marks when they have newline characters and have BigQuery accept the records, we would need to add the following two parameters that are currently not included:

**_allow_jagged_rows = True_**
-        True: Missing values are treated as 'null' but accepted.
-        False: Rows with missing data are treated as bad records

_**allow_quoted_newlines = True**_
-        True: Allow a CSV value to contain a newline character when the value is encased in quotation marks
-        False:  A new line character, regardless of quotations, is always considered a new row

Let me know if you need more information on this and I could send an email together with screenshots for one of the pipelines we're currently running that uses this library